### PR TITLE
Adding test code for closing socket outside of state machine, approxi…

### DIFF
--- a/Source/Mqttify/Private/Mqtt/MqttifyClient.cpp
+++ b/Source/Mqttify/Private/Mqtt/MqttifyClient.cpp
@@ -284,6 +284,14 @@ namespace Mqttify
 		return CurrentState->GetState() == EMqttifyState::Connected;
 	}
 
+	void FMqttifyClient::CloseSocket(int32 Code, const FString& Reason)
+	{
+		if (Socket->IsConnected())
+		{
+			Socket->Close(Code, Reason);
+		}
+	}
+
 	void FMqttifyClient::TransitionTo(
 		const FMqttifyClientState* InPrevious,
 		const TSharedPtr<FMqttifyClientState>& InState

--- a/Source/Mqttify/Private/Mqtt/MqttifyClient.h
+++ b/Source/Mqttify/Private/Mqtt/MqttifyClient.h
@@ -56,6 +56,7 @@ namespace Mqttify
 		virtual FOnMessage& OnMessage() override;
 		virtual const FMqttifyConnectionSettingsRef GetConnectionSettings() const override;
 		virtual bool IsConnected() const override;
+		virtual void CloseSocket(int32 Code = 1000, const FString& Reason = {}) override;
 		// ~IMqttifyClient
 
 		// IMqttifyConnectableAsync

--- a/Source/Mqttify/Private/Mqtt/MqttifyConnectionSettings.cpp
+++ b/Source/Mqttify/Private/Mqtt/MqttifyConnectionSettings.cpp
@@ -21,6 +21,7 @@ FMqttifyConnectionSettings::FMqttifyConnectionSettings(
 	const uint8 InMaxConnectionRetries,
 	const uint8 InMaxPacketRetries,
 	const bool bInShouldVerifyCertificate,
+	const uint32 InSessionExpiryInterval,
 	FString&& InClientId
 	)
 	: MaxPacketSize{InMaxPacketSize}
@@ -40,6 +41,7 @@ FMqttifyConnectionSettings::FMqttifyConnectionSettings(
 	, MaxConnectionRetries{InMaxConnectionRetries}
 	, MaxPacketRetries{InMaxPacketRetries}
 	, bShouldVerifyServerCertificate{bInShouldVerifyCertificate}
+	, SessionExpiryInterval(InSessionExpiryInterval)
 {
 	if (ClientId.IsEmpty())
 	{
@@ -110,6 +112,7 @@ TSharedPtr<FMqttifyConnectionSettings> FMqttifyConnectionSettings::CreateShared(
 	const uint8 InMaxConnectionRetries,
 	const uint8 InMaxPacketRetries,
 	const bool bInShouldVerifyCertificate,
+	const uint32 InSessionExpiryInterval,
 	FString&& InClientId
 	)
 {
@@ -153,6 +156,7 @@ TSharedPtr<FMqttifyConnectionSettings> FMqttifyConnectionSettings::CreateShared(
 			InMaxConnectionRetries,
 			InMaxPacketRetries,
 			bInShouldVerifyCertificate,
+			InSessionExpiryInterval,
 			MoveTemp(InClientId));
 	}
 
@@ -174,6 +178,7 @@ TSharedPtr<FMqttifyConnectionSettings> FMqttifyConnectionSettings::CreateShared(
 	const uint8 InMaxConnectionRetries,
 	const uint8 InMaxPacketRetries,
 	const bool bInShouldVerifyCertificate,
+	const uint32 InSessionExpiryInterval,
 	FString&& InClientId
 	)
 {
@@ -219,6 +224,7 @@ TSharedPtr<FMqttifyConnectionSettings> FMqttifyConnectionSettings::CreateShared(
 			InMaxConnectionRetries,
 			InMaxPacketRetries,
 			bInShouldVerifyCertificate,
+			InSessionExpiryInterval,
 			MoveTemp(InClientId));
 	}
 

--- a/Source/Mqttify/Private/Socket/Interface/MqttifySocketBase.h
+++ b/Source/Mqttify/Private/Socket/Interface/MqttifySocketBase.h
@@ -41,6 +41,8 @@ namespace Mqttify
 		virtual void Connect() = 0;
 		/// @brief Disconnect connect from the host.
 		virtual void Disconnect() = 0;
+		/// @brief Close socket.
+		virtual void Close(int32 Code = 1000, const FString& Reason = {}) = 0;
 		/// @brief Check if the Socket is connected.
 		virtual bool IsConnected() const = 0;
 

--- a/Source/Mqttify/Private/Socket/MqttifySecureSocket.cpp
+++ b/Source/Mqttify/Private/Socket/MqttifySecureSocket.cpp
@@ -149,6 +149,11 @@ namespace Mqttify
 		}
 	}
 
+	void FMqttifySecureSocket::Close(int32 Code, const FString& Reason)
+	{
+		unimplemented();
+	}
+
 	void FMqttifySecureSocket::Send(const uint8* InData, uint32 InSize)
 	{
 		bool bShouldDisconnect = false;

--- a/Source/Mqttify/Private/Socket/MqttifySecureSocket.h
+++ b/Source/Mqttify/Private/Socket/MqttifySecureSocket.h
@@ -24,6 +24,7 @@ namespace Mqttify
 		// FMqttifySocketBase
 		virtual void Connect() override;
 		virtual void Disconnect() override;
+		virtual void Close(int32 Code = 1000, const FString& Reason = {}) override;
 
 		virtual void Tick() override;
 		virtual bool IsConnected() const override;

--- a/Source/Mqttify/Private/Socket/MqttifyWebSocket.cpp
+++ b/Source/Mqttify/Private/Socket/MqttifyWebSocket.cpp
@@ -180,6 +180,20 @@ namespace Mqttify
 		}
 	}
 
+	void FMqttifyWebSocket::Close(int32 Code, const FString& Reason)
+	{
+		FScopeLock Lock{ &SocketAccessLock };
+		LOG_MQTTIFY(
+			Display,
+			TEXT("Closing socket on %s, ClientId %s"),
+			*ConnectionSettings->ToString(),
+			*ConnectionSettings->GetClientId());
+		if (Socket.IsValid() && Socket->IsConnected())
+		{
+			Socket->Close(Code, Reason);
+		}
+	}
+
 	void FMqttifyWebSocket::Disconnect_Internal()
 	{
 		FScopeLock Lock{&SocketAccessLock};

--- a/Source/Mqttify/Private/Socket/MqttifyWebSocket.h
+++ b/Source/Mqttify/Private/Socket/MqttifyWebSocket.h
@@ -24,6 +24,7 @@ namespace Mqttify
 		virtual ~FMqttifyWebSocket() override;
 		virtual void Connect() override;
 		virtual void Disconnect() override;
+		virtual void Close(int32 Code = 1000, const FString& Reason = {}) override;
 		virtual void Tick() override;
 		virtual bool IsConnected() const override;
 

--- a/Source/Mqttify/Public/Mqtt/Interface/IMqttifyClient.h
+++ b/Source/Mqttify/Public/Mqtt/Interface/IMqttifyClient.h
@@ -49,4 +49,10 @@ public:
 	 * @return Is client currently connected?
 	 */
 	virtual bool IsConnected() const = 0;
+
+	/**
+	 * @warning May be unimplemented depending on implementation.
+	 * @sa IWebSocket::Close
+	 */
+	virtual void CloseSocket(int32 Code = 1000, const FString& Reason = {}) = 0;
 };

--- a/Source/Mqttify/Public/Mqtt/MqttifyConnectionSettings.h
+++ b/Source/Mqttify/Public/Mqtt/MqttifyConnectionSettings.h
@@ -56,6 +56,9 @@ private:
 	/// @breif Verify the server certificate.
 	bool bShouldVerifyServerCertificate;
 
+	/// @brief Session expiration interval (seconds) for reconnect.
+	uint32 SessionExpiryInterval = 0;
+
 public:
 	/// @brief Copy constructor.
 	FMqttifyConnectionSettings(const FMqttifyConnectionSettings& Other)
@@ -76,6 +79,7 @@ public:
 		MaxConnectionRetries = Other.MaxConnectionRetries;
 		MaxPacketRetries = Other.MaxPacketRetries;
 		bShouldVerifyServerCertificate = Other.bShouldVerifyServerCertificate;
+		SessionExpiryInterval = Other.SessionExpiryInterval;
 		MaxPacketSize = Other.MaxPacketSize;
 	}
 
@@ -132,6 +136,9 @@ public:
 	/// @brief Whether to verify the server certificate.
 	bool ShouldVerifyServerCertificate() const { return bShouldVerifyServerCertificate; }
 
+	/// @brief Session expiration interval, see MQTT 5 spec.
+	uint32 GetSessionExpiryInterval() const { return SessionExpiryInterval; }
+
 	/**
 	 * @brief Generates a deterministic ClientId based on the connection settings.
 	 * We're using the host, path and username to generate a unique id.
@@ -164,6 +171,7 @@ public:
 		uint8 InMaxConnectionRetries,
 		uint8 InMaxPacketRetries,
 		bool bInShouldVerifyCertificate,
+		uint32 InSessionExpiryInterval,
 		FString&& InClientId = {}
 		);
 
@@ -181,6 +189,7 @@ public:
 		uint8 InMaxConnectionRetries,
 		uint8 InMaxPacketRetries,
 		bool bInShouldVerifyCertificate,
+		uint32 InSessionExpiryInterval,
 		FString&& InClientId = {}
 		);
 
@@ -202,6 +211,7 @@ public:
 		const uint8 InMaxConnectionRetries,
 		const uint8 InMaxPacketRetries,
 		const bool bInShouldVerifyServerCertificate,
+		const uint32 InSessionExpiryInterval,
 		FString&& InClientId
 		)
 	{
@@ -223,6 +233,7 @@ public:
 				InMaxConnectionRetries,
 				InMaxPacketRetries,
 				bInShouldVerifyServerCertificate,
+				InSessionExpiryInterval,
 				MoveTemp(InClientId)));
 	}
 
@@ -273,6 +284,7 @@ private:
 		uint8 InMaxConnectionRetries,
 		uint8 InMaxPacketRetries,
 		bool bInShouldVerifyCertificate,
+		uint32 InSessionExpiryInterval,
 		FString&& InClientId = TEXT("")
 		);
 

--- a/Source/Mqttify/Public/Mqtt/MqttifyConnectionSettingsBuilder.h
+++ b/Source/Mqttify/Public/Mqtt/MqttifyConnectionSettingsBuilder.h
@@ -22,6 +22,7 @@ private:
 	uint8 MaxPacketRetries = 5;
 	uint16 InitialRetryIntervalSeconds = 3.0f;
 	bool bShouldVerifyCertificate = true;
+	uint32 SessionExpiryInterval = 0;
 	EMqttifyProtocolVersion MqttProtocolVersion = EMqttifyProtocolVersion::Mqtt_5;
 	EMqttifyThreadMode ThreadMode = EMqttifyThreadMode::BackgroundThreadWithCallbackMarshalling;
 
@@ -145,6 +146,17 @@ public:
 		return *this;
 	}
 
+	/**
+	 * @brief Sets the session expiry interval (seconds).
+	 * @param InSessionExpiryInterval The session expiry interval in seconds.
+	 * @return A reference to this builder.
+	 */
+	FMqttifyConnectionSettingsBuilder& SetSessionExpiryInterval(const uint32 InSessionExpiryInterval)
+	{
+		SessionExpiryInterval = InSessionExpiryInterval;
+		return *this;
+	}
+
 	FMqttifyConnectionSettingsBuilder& SetCredentialsProvider(
 		const TSharedRef<IMqttifyCredentialsProvider>& InCredentialsProvider
 		)
@@ -185,6 +197,7 @@ public:
 				       MaxConnectionRetries,
 				       MaxPacketRetries,
 				       bShouldVerifyCertificate,
+					   SessionExpiryInterval,
 				       FString{ClientId})
 			       : FMqttifyConnectionSettings::CreateShared(
 				       Url,
@@ -200,6 +213,7 @@ public:
 				       MaxConnectionRetries,
 				       MaxPacketRetries,
 				       bShouldVerifyCertificate,
+					   SessionExpiryInterval,
 				       FString{ClientId});
 	}
 };


### PR DESCRIPTION
…mating a 1006 socket close error.  ex. UE can use console command to trigger.  Add support for MQTT 5 SessionExpiryInterval on connect so broker can maintain session state.

Issue here:

`LogMqttify: Error: [void Mqttify::FMqttifyWebSocket::HandleWebSocketConnectionClosed(const int32, const FString &, const bool)]: Socket Connection Closed Connection wss:<REDACTED>, ClientId <REDACTED>: Status 1006, Reason , bWasClean 0`

with logging added before this pull request:

`LogMqttify: [void __cdecl Mqttify::FMqttifyClientConnectingState::OnReceivePacket(const class TSharedPtr<class FArrayReader,1> &)]: Mqtt_5 connect success. GetSessionPresent(): FALSE.`

after sending the property:

`LogMqttify: [void __cdecl Mqttify::FMqttifyClientConnectingState::OnReceivePacket(const class TSharedPtr<class FArrayReader,1> &)]: Mqtt_5 connect success. GetSessionPresent(): TRUE.`

session is preserved as expected (tested subscriptions).

CloseSocket was used to test with a console command, error code and reason may not get piped through depending on underlying implementation.

Possibly needs a follow-up change to notify when GetSessionPresent() is FALSE when TRUE is expected on a reconnection.