### PR TITLE
chore(build): set CppStandard to Cpp20 for UE 5.6 compatibility

### DIFF
--- a/Source/Mqttify/Mqttify.Build.cs
+++ b/Source/Mqttify/Mqttify.Build.cs
@@ -37,7 +37,7 @@ public class Mqttify : ModuleRules
 		AddEngineThirdPartyPrivateStaticDependencies(Target, "OpenSSL");
 
 		// Build
-		CppStandard = CppStandardVersion.Cpp17;
+		CppStandard = CppStandardVersion.Cpp20;
 		PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "Public"));
 		PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private"));
 

--- a/Source/Mqttify/Private/Mqtt/Commands/MqttifyPublish.cpp
+++ b/Source/Mqttify/Private/Mqtt/Commands/MqttifyPublish.cpp
@@ -55,7 +55,6 @@ namespace Mqttify
 				TEXT("[Publish (Connection %s, ClientId %s)] %s Expected: Actual: %s"),
 				*Settings->GetHost(),
 				*Settings->GetClientId(),
-				MqttifyPacketType::InvalidPacketType,
 				EnumToTCharString(EMqttifyPacketType::PubAck),
 				EnumToTCharString(InPacket->GetPacketType()));
 			Abandon();

--- a/Source/Mqttify/Private/Mqtt/Commands/MqttifySubscribe.cpp
+++ b/Source/Mqttify/Private/Mqtt/Commands/MqttifySubscribe.cpp
@@ -52,7 +52,6 @@ namespace Mqttify
 			LOG_MQTTIFY(
 				Error,
 				TEXT("[Subscribe] %s Expected: Actual: %s"),
-				MqttifyPacketType::InvalidPacketType,
 				EnumToTCharString(EMqttifyPacketType::SubAck),
 				EnumToTCharString(InPacket->GetPacketType()));
 			Abandon();

--- a/Source/Mqttify/Private/Mqtt/Commands/MqttifyUnsubscribe.cpp
+++ b/Source/Mqttify/Private/Mqtt/Commands/MqttifyUnsubscribe.cpp
@@ -71,7 +71,6 @@ namespace Mqttify
 				TEXT("[Unsubscribe  (Connection %s, ClientId %s)] %s Expected: Actual: %s"),
 				*Settings->GetHost(),
 				*Settings->GetClientId(),
-				MqttifyPacketType::InvalidPacketType,
 				EnumToTCharString(EMqttifyPacketType::UnsubAck),
 				EnumToTCharString(InPacket->GetPacketType()));
 			Abandon();


### PR DESCRIPTION
## Description
Updated the CppStandard in the build configuration to Cpp20 to align with Unreal Engine 5.6 default settings.

## Changes
- Updated `CppStandard` from `Cpp17` to `Cpp20` in `Mqttify.Build.cs`.

## Rational
UE 5.6 sets the default C++ version to Cpp20, so this change ensures compatibility and alignment with the engine's default settings.
