### PR TITLE
refactor(secure-socket)!: overhaul TLS I/O and handshake; add SslConnecting state

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -41,7 +41,7 @@ BreakInheritanceList: AfterColon
 BreakStringLiterals: false
 ColumnLimit: 120
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
-Cpp11BracedListStyle: false
+Cpp11BracedListStyle: true
 IncludeCategories: 
   - Regex: '^<.*'
     Priority: 1

--- a/Source/Mqttify/Private/Socket/Interface/MqttifySocketBase.cpp
+++ b/Source/Mqttify/Private/Socket/Interface/MqttifySocketBase.cpp
@@ -10,7 +10,7 @@ namespace Mqttify
 {
 	FMqttifySocketBase::~FMqttifySocketBase()
 	{
-		FScopeLock Lock{ &SocketAccessLock };
+		FScopeLock Lock{&SocketAccessLock};
 		OnConnectDelegate.Clear();
 		OnDisconnectDelegate.Clear();
 		OnDataReceiveDelegate.Clear();
@@ -36,10 +36,10 @@ namespace Mqttify
 		while (DataBuffer.Num() >= 1)
 		{
 			constexpr int32 PacketStartIndex = 0;
-			uint32 RemainingLength = 0;
-			uint32 Multiplier = 1;
-			int32 Index = 1;
-			bool bHaveRemainingLength = false;
+			uint32 RemainingLength           = 0;
+			uint32 Multiplier                = 1;
+			int32 Index                      = 1;
+			bool bHaveRemainingLength        = false;
 
 			for (; Index < 5; ++Index)
 			{
@@ -87,7 +87,8 @@ namespace Mqttify
 			}
 
 			TSharedPtr<FArrayReader> Packet = MakeShared<FArrayReader>(false);
-			Packet->Append(&DataBuffer[PacketStartIndex], TotalPacketSize);
+			Packet->SetNumUninitialized(TotalPacketSize);
+			FMemory::Memcpy(Packet->GetData(), DataBuffer.GetData(), TotalPacketSize);
 
 			DataBuffer.RemoveAt(0, TotalPacketSize, EAllowShrinking::No);
 

--- a/Source/Mqttify/Private/Socket/MqttifySocketState.h
+++ b/Source/Mqttify/Private/Socket/MqttifySocketState.h
@@ -10,6 +10,7 @@ namespace Mqttify
 		Disconnected,
 		Connecting,
 		Connected,
+		SslConnecting,
 		Disconnecting
 	};
 
@@ -22,6 +23,8 @@ namespace Mqttify
 				return TEXT("Disconnected");
 			case EMqttifySocketState::Connecting:
 				return TEXT("Connecting");
+			case EMqttifySocketState::SslConnecting:
+				return TEXT("SslConnecting");
 			case EMqttifySocketState::Connected:
 				return TEXT("Connected");
 			case EMqttifySocketState::Disconnecting:


### PR DESCRIPTION
- Replace dual BIOs with a single custom BIO via `SSL_set_bio`
- Drive the TLS handshake in `Tick()` using a new `SslConnecting` state
- Send/recv: use `SSL_write`/`SSL_read_ex` with WANT_* handling; loop 
  for
 partial sends on plain sockets; chunked reads via `ReadAvailableData`
- Security: min TLS 1.2, tighter ciphers, P-256/384/521 curves, hostname
 verification (`SSL_set1_host`, `X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS`), 
 stronger cert verify callback
- Socket opts: reuse addr, non-blocking, TCP_NODELAY, linger off, recv 
 err
- Debugging: SSL/BIO state logs (non-shipping) and clearer OpenSSL error
 strings
- Buffering: explicit size + `FMemory::Memcpy` when building 
 `FArrayReader`
- Helpers: `ReceiveFromSocket`, `ReceiveFromSSL`, `ReadAvailableData`, 
 `AppendAndProcess`, `GetLastSslErrorString`
- State/teardown: `IsConnected()` and disconnect logic account for 
 `SslConnecting`
- Tests: update TLS echo and BSD socket specs
- style: enable `Cpp11BracedListStyle`; minor spacing/align fixes