### PR TITLE
feat(connection): add max inbound buffer cap & enforce in sockets

### DIFF
--- a/Source/Mqttify/Private/Mqtt/MqttifyConnectionSettings.cpp
+++ b/Source/Mqttify/Private/Mqtt/MqttifyConnectionSettings.cpp
@@ -11,6 +11,7 @@ FMqttifyConnectionSettings::FMqttifyConnectionSettings(
 	const int16 InPort,
 	const FMqttifyCredentialsProviderRef& InCredentialsProvider,
 	const uint32 InMaxPacketSize,
+	const uint32 InMaxBufferSize,
 	const uint16 InPacketRetryIntervalSeconds,
 	const double InPacketRetryBackoffMultiplier,
 	const uint16 InMaxPacketRetryIntervalSeconds,
@@ -25,6 +26,7 @@ FMqttifyConnectionSettings::FMqttifyConnectionSettings(
 	FString&& InClientId
 	)
 	: MaxPacketSize{InMaxPacketSize}
+	, MaxBufferSize{InMaxBufferSize}
 	, ClientId{InClientId}
 	, Port{InPort}
 	, Host{InHost}
@@ -102,6 +104,7 @@ uint32 FMqttifyConnectionSettings::GetHashCode() const
 TSharedPtr<FMqttifyConnectionSettings> FMqttifyConnectionSettings::CreateShared(
 	const FString& InURL,
 	const uint32 InMaxPacketSize,
+	const uint32 InMaxBufferSize,
 	const uint16 InPacketRetryIntervalSeconds,
 	const double InBackoffMultiplier,
 	const uint16 InMaxPacketRetryIntervalSeconds,
@@ -132,7 +135,8 @@ TSharedPtr<FMqttifyConnectionSettings> FMqttifyConnectionSettings::CreateShared(
 		// Parse credentials
 		FString Username = Matcher.GetCaptureGroup(2);
 		FString Password = Matcher.GetCaptureGroup(3);
-		const TSharedRef<IMqttifyCredentialsProvider> CredentialsProvider = MakeShared<FMqttifyBasicCredentialsProvider>(
+		const TSharedRef<IMqttifyCredentialsProvider> CredentialsProvider = MakeShared<
+			FMqttifyBasicCredentialsProvider>(
 			MoveTemp(Username),
 			MoveTemp(Password));
 
@@ -146,6 +150,7 @@ TSharedPtr<FMqttifyConnectionSettings> FMqttifyConnectionSettings::CreateShared(
 			Port,
 			CredentialsProvider,
 			InMaxPacketSize,
+			InMaxBufferSize,
 			InPacketRetryIntervalSeconds,
 			InBackoffMultiplier,
 			InMaxPacketRetryIntervalSeconds,
@@ -168,6 +173,7 @@ TSharedPtr<FMqttifyConnectionSettings> FMqttifyConnectionSettings::CreateShared(
 	const FString& InURL,
 	const TSharedRef<IMqttifyCredentialsProvider>& CredentialsProvider,
 	const uint32 InMaxPacketSize,
+	const uint32 InMaxBufferSize,
 	const uint16 InPacketRetryIntervalSeconds,
 	const double InBackoffMultiplier,
 	const uint16 InMaxPacketRetryIntervalSeconds,
@@ -214,6 +220,7 @@ TSharedPtr<FMqttifyConnectionSettings> FMqttifyConnectionSettings::CreateShared(
 			Port,
 			CredentialsProvider,
 			InMaxPacketSize,
+			InMaxBufferSize,
 			InPacketRetryIntervalSeconds,
 			InBackoffMultiplier,
 			InMaxPacketRetryIntervalSeconds,
@@ -258,16 +265,16 @@ int32 FMqttifyConnectionSettings::DefaultPort(const EMqttifyConnectionProtocol P
 {
 	switch (Protocol)
 	{
-	case EMqttifyConnectionProtocol::Mqtt:
-		return 1883;
-	case EMqttifyConnectionProtocol::Mqtts:
-		return 8883;
-	case EMqttifyConnectionProtocol::Ws:
-		return 80;
-	case EMqttifyConnectionProtocol::Wss:
-		return 443;
-	default:
-		return 1883;
+		case EMqttifyConnectionProtocol::Mqtt:
+			return 1883;
+		case EMqttifyConnectionProtocol::Mqtts:
+			return 8883;
+		case EMqttifyConnectionProtocol::Ws:
+			return 80;
+		case EMqttifyConnectionProtocol::Wss:
+			return 443;
+		default:
+			return 1883;
 	}
 }
 
@@ -327,23 +334,23 @@ FString FMqttifyConnectionSettings::ToString() const
 	// Protocol
 	switch (ConnectionProtocol)
 	{
-	case EMqttifyConnectionProtocol::Mqtt:
-		Result += TEXT("mqtt://");
-		break;
+		case EMqttifyConnectionProtocol::Mqtt:
+			Result += TEXT("mqtt://");
+			break;
 
-	case EMqttifyConnectionProtocol::Mqtts:
-		Result += TEXT("mqtts://");
-		break;
+		case EMqttifyConnectionProtocol::Mqtts:
+			Result += TEXT("mqtts://");
+			break;
 
-	case EMqttifyConnectionProtocol::Ws:
-		Result += TEXT("ws://");
-		break;
+		case EMqttifyConnectionProtocol::Ws:
+			Result += TEXT("ws://");
+			break;
 
-	case EMqttifyConnectionProtocol::Wss:
-		Result += TEXT("wss://");
-		break;
+		case EMqttifyConnectionProtocol::Wss:
+			Result += TEXT("wss://");
+			break;
 
-	default: checkNoEntry();
+		default: checkNoEntry();
 	}
 
 	// Hostname and port
@@ -377,23 +384,23 @@ FString FMqttifyConnectionSettings::ToConnectionString() const
 	// Protocol
 	switch (ConnectionProtocol)
 	{
-	case EMqttifyConnectionProtocol::Mqtt:
-		Result += TEXT("mqtt://");
-		break;
+		case EMqttifyConnectionProtocol::Mqtt:
+			Result += TEXT("mqtt://");
+			break;
 
-	case EMqttifyConnectionProtocol::Mqtts:
-		Result += TEXT("mqtts://");
-		break;
+		case EMqttifyConnectionProtocol::Mqtts:
+			Result += TEXT("mqtts://");
+			break;
 
-	case EMqttifyConnectionProtocol::Ws:
-		Result += TEXT("ws://");
-		break;
+		case EMqttifyConnectionProtocol::Ws:
+			Result += TEXT("ws://");
+			break;
 
-	case EMqttifyConnectionProtocol::Wss:
-		Result += TEXT("wss://");
-		break;
+		case EMqttifyConnectionProtocol::Wss:
+			Result += TEXT("wss://");
+			break;
 
-	default: checkNoEntry();
+		default: checkNoEntry();
 	}
 
 	const auto [Password, Username] = CredentialsProvider->GetCredentials();

--- a/Source/Mqttify/Private/Socket/MqttifySecureSocket.h
+++ b/Source/Mqttify/Private/Socket/MqttifySecureSocket.h
@@ -32,7 +32,7 @@ namespace Mqttify
 	private:
 		virtual void Send(const TSharedRef<IMqttifyControlPacket>& InPacket) override;
 		virtual void Send(const uint8* InData, uint32 InSize) override;
-		static constexpr uint32 kBufferSize  = 2 * 1024 * 1024;
+		static constexpr uint32 kBufferSize = 2 * 1024 * 1024;
 		static constexpr uint32 kMaxChunkSize = 16 * 1024;
 		FUniqueSocket Socket;
 
@@ -53,7 +53,8 @@ namespace Mqttify
 		bool ReceiveFromSocket(int32 Want, TArray<uint8>& Tmp, size_t& OutBytesRead) const;
 		// Reads pending data (if any) using the provided reader lambda.
 		// The reader must have signature: bool(int32 Want, TArray<uint8>& Tmp, int32& BytesRead).
-		bool ReadAvailableData(const TUniqueFunction<bool(const int32 Want, TArray<uint8>& Tmp, size_t& OutBytesRead)>&& Reader);
+		bool ReadAvailableData(
+			const TUniqueFunction<bool(const int32 Want, TArray<uint8>& Tmp, size_t& OutBytesRead)>&& Reader);
 #if WITH_SSL
 		bool InitializeSSL();
 		void CleanupSSL();
@@ -68,12 +69,12 @@ namespace Mqttify
 		static long SocketBioCtrl(BIO* Bio, int Cmd, long Num, void* Ptr);
 		static int SocketBioCreate(BIO* Bio);
 		static int SocketBioDestroy(BIO* Bio);
-		
+
 #if !UE_BUILD_SHIPPING
 		void DebugSslBioState(EMqttifySocketState State);
 		FString LastSslBioDebugLog{};
 #endif // !UE_BUILD_SHIPPING
-		
+
 #endif // WITH_SSL
 	};
 } // namespace Mqttify


### PR DESCRIPTION
- Introduce MaxBufferSize to FMqttifyConnectionSettings (default 64MB) 
with getter.
- Extend FMqttifyConnectionSettingsBuilder with SetMaxBufferSize() and 
plumb value through Build().
- Enforce cap in FMqttifySecureSocket::AppendAndProcess and 
FMqttifyWebSocket::OnRawMessage:
- track buffer size under lock, log error, and disconnect if cap 
exceeded.
- style: normalize formatting & consistency across codebase
- Compact trivial constructors/structs; align parameters; tidy 
switches/spacing.