### PR TITLE
perf(socket): parse with sliding offset to avoid O(n) front erases

### DIFF
--- a/Source/Mqttify/Private/Socket/Interface/MqttifySocketBase.h
+++ b/Source/Mqttify/Private/Socket/Interface/MqttifySocketBase.h
@@ -27,7 +27,7 @@ namespace Mqttify
 		/// @return The OnDisconnect event.
 		FOnDisconnectDelegate& GetOnDisconnectDelegate() { return OnDisconnectDelegate; }
 
-		DECLARE_TS_MULTICAST_DELEGATE_OneParam(FOnDataReceivedDelegate, const TSharedPtr<FArrayReader>& /* Data */)
+		DECLARE_TS_MULTICAST_DELEGATE_OneParam(FOnDataReceivedDelegate, const TSharedPtr<FArrayReader>& /* Data */);
 		/// @return The OnDataReceived event.
 		FOnDataReceivedDelegate& GetOnDataReceivedDelegate() { return OnDataReceiveDelegate; }
 
@@ -72,6 +72,7 @@ namespace Mqttify
 		FOnConnectDelegate OnConnectDelegate{};
 		FOnDisconnectDelegate OnDisconnectDelegate{};
 		TArray<uint8> DataBuffer;
+		int32 DataBufferReadOffset = 0; // number of bytes already consumed from the front
 		const FMqttifyConnectionSettingsRef ConnectionSettings;
 
 	protected:


### PR DESCRIPTION
- Stop doing RemoveAt(0, …) on every packet; keep a read offset and 
memcpy from Base + offset
- Batch packets under the lock, then dispatch after unlocking (no 
reentrancy)
- Compact the buffer only when thresholds are met (min bytes and %), not
per packet