### PR TITLE
fix(mqtt): correct wildcard matching and speed up message dispatch

### DIFF
--- a/Source/Mqttify/Private/Mqtt/State/MqttifyClientContext.h
+++ b/Source/Mqttify/Private/Mqtt/State/MqttifyClientContext.h
@@ -97,6 +97,12 @@ namespace Mqttify
 		TMap<FString, TSharedRef<FOnMessage>> OnMessageDelegates{};
 		mutable FCriticalSection OnMessageDelegatesCriticalSection{};
 
+		/// @brief Exact-topic cache for standard filters
+		TMap<FString, TSharedRef<FOnMessage>> ExactDelegates{};
+		
+		/// @brief Cache for filters with wind cards
+		TArray<TPair<FMqttifyTopicFilter, TSharedRef<FOnMessage>>> WildcardDelegates{};
+
 		/// @brief Promises for when a disconnect is complete.
 		TArray<TSharedPtr<TPromise<TMqttifyResult<void>>>> OnDisconnectPromises;
 		mutable FCriticalSection OnDisconnectPromisesCriticalSection{};

--- a/Source/Mqttify/Private/Tests/Mqtt/MqttifyClientDispatch.spec.cpp
+++ b/Source/Mqttify/Private/Tests/Mqtt/MqttifyClientDispatch.spec.cpp
@@ -1,0 +1,63 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "Mqtt/MqttifyMessage.h"
+#include "Mqtt/Delegates/OnMessage.h"
+#include "Mqtt/MqttifyConnectionSettings.h"
+#include "Mqtt/MqttifyConnectionSettingsBuilder.h"
+#include "Mqtt/MqttifyQualityOfService.h"
+#include "Mqtt/State/MqttifyClientContext.h"
+
+using namespace Mqttify;
+
+BEGIN_DEFINE_SPEC(
+	FMqttifyClientDispatchSpec,
+	"Mqttify.Automation.ClientDispatchWildcardRouting",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ClientContext | EAutomationTestFlags::ServerContext |
+	EAutomationTestFlags::CommandletContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FMqttifyClientDispatchSpec)
+
+void FMqttifyClientDispatchSpec::Define()
+{
+	Describe("FMqttifyClientContext dispatch routes to exact and wildcard delegates", [this]
+	{
+		It("Dispatch should invoke exact, '+', and '#' delegates for matching topic", [this]
+		{
+			FMqttifyConnectionSettingsBuilder Builder(TEXT("mqtt://user:pass@localhost:1883"));
+			const TSharedPtr<FMqttifyConnectionSettings> Settings = Builder.Build();
+			TestTrue(TEXT("Settings should be valid"), Settings.IsValid());
+			const FMqttifyConnectionSettingsRef SettingsRef = Settings.ToSharedRef();
+
+			TSharedRef<FMqttifyClientContext> Context = MakeShared<FMqttifyClientContext>(SettingsRef);
+
+			static const TCHAR* ExactTopic = TEXT("sensors/uk/temperatures");
+			bool bExactCalled = false;
+			Context->GetMessageDelegate(ExactTopic)->AddLambda([&](const FMqttifyMessage&){ bExactCalled = true; });
+
+			bool bPlusCalled = false;
+			Context->GetMessageDelegate(TEXT("sensors/+/temperatures"))->AddLambda([&](const FMqttifyMessage&){ bPlusCalled = true; });
+
+			bool bHashCalled = false;
+			Context->GetMessageDelegate(TEXT("sensors/#"))->AddLambda([&](const FMqttifyMessage&){ bHashCalled = true; });
+
+			FMqttifyMessage Msg{FString{ExactTopic}, TArray<uint8>{}, false, EMqttifyQualityOfService::AtMostOnce};
+			Context->CompleteMessage(MoveTemp(Msg));
+
+			TestTrue(TEXT("Exact delegate fired"), bExactCalled);
+			TestTrue(TEXT("'+' filter delegate fired"), bPlusCalled);
+			TestTrue(TEXT("'#' filter delegate fired"), bHashCalled);
+
+			bExactCalled = false;
+			bPlusCalled = false;
+			bHashCalled = false;
+			FMqttifyMessage Msg2{FString{TEXT("other/topic")}, TArray<uint8>{}, false, EMqttifyQualityOfService::AtMostOnce};
+			Context->CompleteMessage(MoveTemp(Msg2));
+			TestFalse(TEXT("Exact delegate should not fire for other/topic"), bExactCalled);
+			TestFalse(TEXT("'+' filter should not fire for other/topic"), bPlusCalled);
+			// sensors/# will not match other/topic either, so remains false
+			TestFalse(TEXT("'#' filter should not fire for other/topic"), bHashCalled);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/Mqttify/Private/Tests/Mqtt/MqttifyTopicFilter.spec.cpp
+++ b/Source/Mqttify/Private/Tests/Mqtt/MqttifyTopicFilter.spec.cpp
@@ -1,0 +1,86 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "Mqtt/MqttifyTopicFilter.h"
+
+BEGIN_DEFINE_SPEC(
+	FMqttifyTopicFilterSpec,
+	"Mqttify.Automation.MqttifyTopicFilter",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ClientContext | EAutomationTestFlags::ServerContext |
+	EAutomationTestFlags::CommandletContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FMqttifyTopicFilterSpec)
+
+void FMqttifyTopicFilterSpec::Define()
+{
+	Describe("FMqttifyTopicFilter::MatchesWildcard", [this]
+	{
+		It("Basic single-level '+' matches exactly one level (including empty)", [this]
+		{
+			FMqttifyTopicFilter Filter1{TEXT("topic/+/data")};
+			TestTrue(TEXT("topic/x/data matches"), Filter1.MatchesWildcard(TEXT("topic/x/data")));
+			TestTrue(TEXT("topic//data matches empty level"), Filter1.MatchesWildcard(TEXT("topic//data")));
+			TestTrue(TEXT("topic/123/data matches"), Filter1.MatchesWildcard(TEXT("topic/123/data")));
+			TestFalse(TEXT("topic/x/data/extra does not match"), Filter1.MatchesWildcard(TEXT("topic/x/data/extra")));
+			TestFalse(TEXT("topic/x does not match"), Filter1.MatchesWildcard(TEXT("topic/x")));
+		});
+
+		It("Multi-level '#' placement and matching", [this]
+		{
+			FMqttifyTopicFilter Filter2{TEXT("topic/#")};
+			TestTrue(TEXT("topic matches topic/#"), Filter2.MatchesWildcard(TEXT("topic")));
+			TestTrue(TEXT("topic/ matches topic/#"), Filter2.MatchesWildcard(TEXT("topic/")));
+			TestTrue(TEXT("topic/a matches topic/#"), Filter2.MatchesWildcard(TEXT("topic/a")));
+			TestTrue(TEXT("topic/a/b matches topic/#"), Filter2.MatchesWildcard(TEXT("topic/a/b")));
+
+			FMqttifyTopicFilter Filter3{TEXT("#")};
+			TestTrue(TEXT("# matches everything (empty not possible in topics, but any topic)"), Filter3.MatchesWildcard(TEXT("anything")));
+		});
+
+		It("Invalid wildcard placement should not match (treated as invalid filter)", [this]
+		{
+			TestFalse(TEXT("'a#' invalid placement"), FMqttifyTopicFilter{TEXT("a#")}.MatchesWildcard(TEXT("a")));
+			TestFalse(TEXT("'a/#/b' invalid placement"), FMqttifyTopicFilter{TEXT("a/#/b")}.MatchesWildcard(TEXT("a/x/b")));
+			TestFalse(TEXT("'a/+b' invalid placement"), FMqttifyTopicFilter{TEXT("a/+b")}.MatchesWildcard(TEXT("a/xb")));
+			TestFalse(TEXT("'a+' invalid placement"), FMqttifyTopicFilter{TEXT("a+")}.MatchesWildcard(TEXT("a")));
+			TestFalse(TEXT("'+/b+' invalid placement"), FMqttifyTopicFilter{TEXT("+/b+")}.MatchesWildcard(TEXT("x/by")));
+			TestFalse(TEXT("'a/##' invalid placement"), FMqttifyTopicFilter{TEXT("a/##")}.MatchesWildcard(TEXT("a")));
+			TestFalse(TEXT("'a/#b' invalid placement"), FMqttifyTopicFilter{TEXT("a/#b")}.MatchesWildcard(TEXT("a")));
+		});
+
+		It("Absolute vs relative leading slash must match", [this]
+		{
+			TestTrue(TEXT("/a/+ matches /a/b"), FMqttifyTopicFilter{TEXT("/a/+")}.MatchesWildcard(TEXT("/a/b")));
+			TestTrue(TEXT("/a/+ matches /a/ (empty last level)"), FMqttifyTopicFilter{TEXT("/a/+")}.MatchesWildcard(TEXT("/a/")));
+			TestFalse(TEXT("/a/+ does not match a/b"), FMqttifyTopicFilter{TEXT("/a/+")}.MatchesWildcard(TEXT("a/b")));
+
+			TestTrue(TEXT("a/+ matches a/b"), FMqttifyTopicFilter{TEXT("a/+")}.MatchesWildcard(TEXT("a/b")));
+			TestTrue(TEXT("a/+ matches a/ (empty last level)"), FMqttifyTopicFilter{TEXT("a/+")}.MatchesWildcard(TEXT("a/")));
+			TestFalse(TEXT("a/+ does not match /a/b"), FMqttifyTopicFilter{TEXT("a/+")}.MatchesWildcard(TEXT("/a/b")));
+		});
+
+		It("Trailing slash semantics are strict", [this]
+		{
+			TestTrue(TEXT("a/b/ matches a/b/ only"), FMqttifyTopicFilter{TEXT("a/b/")}.MatchesWildcard(TEXT("a/b/")));
+			TestFalse(TEXT("a/b/ does not match a/b"), FMqttifyTopicFilter{TEXT("a/b/")}.MatchesWildcard(TEXT("a/b")));
+
+			TestTrue(TEXT("a/+/ matches a/x/"), FMqttifyTopicFilter{TEXT("a/+/")}.MatchesWildcard(TEXT("a/x/")));
+			TestTrue(TEXT("a/+/ matches a// (empty level)"), FMqttifyTopicFilter{TEXT("a/+/")}.MatchesWildcard(TEXT("a//")));
+			TestFalse(TEXT("a/+/ does not match a/x"), FMqttifyTopicFilter{TEXT("a/+/")}.MatchesWildcard(TEXT("a/x")));
+		});
+
+		It("Edge cases and empty levels", [this]
+		{
+			TestTrue(TEXT("+/+ matches x/y"), FMqttifyTopicFilter{TEXT("+/+")}.MatchesWildcard(TEXT("x/y")));
+			TestTrue(TEXT("+/+ matches x/ (empty second level)"), FMqttifyTopicFilter{TEXT("+/+")}.MatchesWildcard(TEXT("x/")));
+			TestTrue(TEXT("+/+ matches /y (empty first level)"), FMqttifyTopicFilter{TEXT("+/+")}.MatchesWildcard(TEXT("/y")));
+			TestTrue(TEXT("+/+ matches / (two empty levels)"), FMqttifyTopicFilter{TEXT("+/+")}.MatchesWildcard(TEXT("/")));
+			TestFalse(TEXT("+/+ does not match x"), FMqttifyTopicFilter{TEXT("+/+")}.MatchesWildcard(TEXT("x")));
+			TestFalse(TEXT("+/+ does not match x/y/z"), FMqttifyTopicFilter{TEXT("+/+")}.MatchesWildcard(TEXT("x/y/z")));
+
+			TestTrue(TEXT("home//temp matches itself"), FMqttifyTopicFilter{TEXT("home//temp")}.MatchesWildcard(TEXT("home//temp")));
+			TestTrue(TEXT("home/+/temp must match empty middle level"), FMqttifyTopicFilter{TEXT("home/+/temp")}.MatchesWildcard(TEXT("home//temp")));
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS


### PR DESCRIPTION
fix(mqtt): correct wildcard matching and speed up message dispatch

- Rework `FMqttifyTopicFilter::MatchesWildcard` for proper MQTT `+`/`#` semantics (handles empty segments and leading/trailing slashes; rejects invalid placements).
- Add fast-path dispatch in `FMqttifyClientContext`: exact-topic cache (`ExactDelegates`) and precompiled wildcard cache (`WildcardDelegates`) with proper cleanup on unsubscribe.
- Improve thread marshalling in `MqttifyAsync`: if already on the game thread, run inline instead of hopping via `AsyncTask`.
- Add tests:

  - `MqttifyTopicFilter.spec` covering edge cases for wildcard matching.
  - `MqttifyClientDispatch.spec` for exact/`+`/`#` routing.
  - Extend long-running test to exercise wildcard subs against a real broker.
- Tidy logging and formatting.

fix: #8
Credits: @dynamiquel