### PR TITLE
perf: guard logging, add const refs & move semantics; reduce lock contention

### DIFF
--- a/Source/Mqttify/Private/LogMqttify.h
+++ b/Source/Mqttify/Private/LogMqttify.h
@@ -24,9 +24,12 @@ DECLARE_LOG_CATEGORY_EXTERN(LogMqttify, Display, All);
  */
 #define LOG_MQTTIFY(Verbosity, Format, ...)\
 do {\
+if (UE_LOG_ACTIVE(LogMqttify, Verbosity))\
+{\
 UE_LOG(LogMqttify, Verbosity, TEXT("[%s]: %s"),\
 StringCast<TCHAR>(MQTTIFY_PRETTY_FUNCTION).Get(),\
 *FString::Printf(Format, ##__VA_ARGS__));\
+}\
 } while (0)
 
 namespace Mqttify

--- a/Source/Mqttify/Private/Mqtt/Commands/MqttifyQueueable.cpp
+++ b/Source/Mqttify/Private/Mqtt/Commands/MqttifyQueueable.cpp
@@ -43,7 +43,7 @@ namespace Mqttify
 				TEXT( "(Connection %s, ClientId %s) Sending %s, Attempt %d"),
 				InPacket,
 				*Settings->GetHost(),
-				*Settings->GetClientId(),
+				*Settings->GetClientIdRef(),
 				EnumToTCharString(InPacket->GetPacketType()),
 				PacketTries);
 
@@ -56,7 +56,7 @@ namespace Mqttify
 					TEXT( "(Connection %s, ClientId %s) Socket disconnected while sending packet"),
 					InPacket,
 					*Settings->GetHost(),
-					*Settings->GetClientId());
+					*Settings->GetClientIdRef());
 				Abandon();
 			}
 

--- a/Source/Mqttify/Private/Mqtt/Commands/MqttifyQueueable.h
+++ b/Source/Mqttify/Private/Mqtt/Commands/MqttifyQueueable.h
@@ -149,7 +149,7 @@ namespace Mqttify
 				VeryVerbose,
 				TEXT( "Dispatching Promise Value (Connection %s, ClientId %s): Success: %s" ),
 				*Settings->GetHost(),
-				*Settings->GetClientId(),
+				*Settings->GetClientIdRef(),
 				InValue.HasSucceeded() ? TEXT("true") : TEXT("false"));
 
 			TSharedRef<TPromise<TMqttifyResult<TReturnValue>>> CapturedPromise = CommandPromise;
@@ -160,7 +160,7 @@ namespace Mqttify
 						VeryVerbose,
 						TEXT( "Setting promise value (Connection %s, ClientId %s): Success: %s" ),
 						*CapturedSettings->GetHost(),
-						*CapturedSettings->GetClientId(),
+						*CapturedSettings->GetClientIdRef(),
 						InValue.HasSucceeded() ? TEXT("true") : TEXT("false"));
 					CapturedPromise->SetValue(MoveTemp(InValue));
 				});

--- a/Source/Mqttify/Private/Mqtt/MqttifyClient.h
+++ b/Source/Mqttify/Private/Mqtt/MqttifyClient.h
@@ -40,13 +40,14 @@ namespace Mqttify
 		// IMqttifySubscribableAsync
 		virtual FSubscribesFuture SubscribeAsync(const TArray<FMqttifyTopicFilter>& InTopicFilters) override;
 		virtual FSubscribeFuture SubscribeAsync(FMqttifyTopicFilter&& InTopicFilter) override;
-		virtual FSubscribeFuture SubscribeAsync(FString& InTopicFilter) override;
+		virtual FSubscribeFuture SubscribeAsync(const FString& InTopicFilter) override;
 		// ~IMqttifySubscribableAsync
 
 		// IMqttifyUnsubscribableAsync
 		virtual FUnsubscribesFuture UnsubscribeAsync(const TSet<FString>& InTopicFilters) override;
 		// ~IMqttifyUnsubscribableAsync
 
+	private:
 		// IMqttifyClient
 		virtual FOnConnect& OnConnect() override;
 		virtual FOnDisconnect& OnDisconnect() override;
@@ -66,7 +67,7 @@ namespace Mqttify
 		// IMqttifyDisconnectableAsync
 		virtual FDisconnectFuture DisconnectAsync() override;
 		// ~IMqttifyDisconnectableAsync
-	private:
+
 		void TransitionTo(const FMqttifyClientState* InPrevious, const TSharedPtr<FMqttifyClientState>& InState);
 
 		// FMqttifySocketBase Callbacks
@@ -74,7 +75,9 @@ namespace Mqttify
 		void OnSocketDisconnect() const;
 		void OnReceivePacket(const TSharedPtr<FArrayReader>& InPacket) const;
 		// ~FMqttifySocketBase Callbacks
-	private:
+
+		FSubscribesFuture SubscribeAsync_Internal(TArray<FMqttifyTopicFilter>&& InTopicFilters);
+		
 		/// @brief The current state of the MQTT client.
 		TSharedPtr<FMqttifyClientState> CurrentState;
 		TSharedRef<FMqttifyClientContext> Context;

--- a/Source/Mqttify/Private/Mqtt/MqttifyConnectionSettings.cpp
+++ b/Source/Mqttify/Private/Mqtt/MqttifyConnectionSettings.cpp
@@ -56,6 +56,11 @@ FString FMqttifyConnectionSettings::GetClientId() const
 	return ClientId;
 }
 
+const FString& FMqttifyConnectionSettings::GetClientIdRef() const
+{
+	return ClientId;
+}
+
 uint32 FMqttifyConnectionSettings::GetHashCode() const
 {
 	// We're deliberately not hashing the password or client ID here

--- a/Source/Mqttify/Private/Mqtt/State/MqttifyClientContext.h
+++ b/Source/Mqttify/Private/Mqtt/State/MqttifyClientContext.h
@@ -103,6 +103,12 @@ namespace Mqttify
 		/// @brief Cache for filters with wind cards
 		TArray<TPair<FMqttifyTopicFilter, TSharedRef<FOnMessage>>> WildcardDelegates{};
 
+		/// @brief Initial reserve size for WildcardDelegates to reduce reallocations when first populated
+		static constexpr int32 kWildcardDelegatesInitialReserve = 8;
+
+		/// @brief Initial reserve size for promise arrays to reduce reallocations
+		static constexpr int32 kPromiseInitialReserve = 4;
+
 		/// @brief Promises for when a disconnect is complete.
 		TArray<TSharedPtr<TPromise<TMqttifyResult<void>>>> OnDisconnectPromises;
 		mutable FCriticalSection OnDisconnectPromisesCriticalSection{};

--- a/Source/Mqttify/Public/Mqtt/Interface/IMqttifySubscribableAsync.h
+++ b/Source/Mqttify/Public/Mqtt/Interface/IMqttifySubscribableAsync.h
@@ -46,6 +46,6 @@ namespace Mqttify
 		 * @return A future that contains the result of the connection, which can be checked for success.
 		 * the result contains a result for this topic filter
 		 */
-		virtual FSubscribeFuture SubscribeAsync(FString& InTopicFilter) = 0;
+		virtual FSubscribeFuture SubscribeAsync(const FString& InTopicFilter) = 0;
 	};
 } // namespace Mqttify

--- a/Source/Mqttify/Public/Mqtt/MqttifyConnectionSettings.h
+++ b/Source/Mqttify/Public/Mqtt/MqttifyConnectionSettings.h
@@ -165,6 +165,11 @@ public:
 	FString GetClientId() const;
 
 	/**
+	 * @brief Returns the ClientId by const reference to avoid copies in hot paths.
+	 */
+	const FString& GetClientIdRef() const;
+
+	/**
 	 * @brief Generates a hash code based on the connection settings.
 	 * We ignore the password as we want to use the same Hash if the password changes
 	 * @return The hash code for the connection settings.


### PR DESCRIPTION
- Wrap LOG_MQTTIFY with UE_LOG_ACTIVE to skip expensive formatting when the
  category/verbosity is disabled.
- Add FMqttifyConnectionSettings::GetClientIdRef() and use it in hot paths to
  avoid FString copies.
- Rework SubscribeAsync flow:
  - introduce SubscribeAsync_Internal(TArray&&) to leverage move semantics,
    reserve capacity, and avoid redundant copies.
  - change overload to SubscribeAsync(const FString&), improving const-correctness.
- Client context robustness/perf:
  - snapshot promise/delegate containers before broadcasting to reduce time
    spent under locks and prevent re-entrancy issues.
  - add initial reserve sizes for promise and wildcard arrays.
  - minor cleanup in ID pool and message dispatch path.
- Socket handling: CloseSocket now uses StateLock and relies on idempotent Close
  (no pre-check), aligning with other state interactions.
- Replace remaining GetClientId() log sites with GetClientIdRef().