### PR TITLE
feat(mqtt5/auth): add enhanced authentication (AUTH packets, method/data) and tests

### DIFF
--- a/Source/Mqttify/Private/Tests/Mqtt/MqttifyConnectingEnhancedAuth.spec.cpp
+++ b/Source/Mqttify/Private/Tests/Mqtt/MqttifyConnectingEnhancedAuth.spec.cpp
@@ -1,0 +1,120 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "Mqtt/MqttifyConnectionSettings.h"
+#include "Mqtt/MqttifyConnectionSettingsBuilder.h"
+#include "Mqtt/State/MqttifyClientContext.h"
+#include "Mqtt/State/MqttifyClientConnectingState.h"
+#include "Packets/MqttifyAuthPacket.h"
+#include "Packets/MqttifyConnAckPacket.h"
+#include "Packets/Properties/MqttifyProperty.h"
+#include "Tests/Support/FakeTestSocket.h"
+#include "Mqtt/Interface/IMqttifyCredentialsProvider.h"
+
+using namespace Mqttify;
+
+// Dummy credentials provider used in tests to drive enhanced auth
+class FTestEnhancedAuthProvider final : public IMqttifyCredentialsProvider
+{
+public:
+	virtual ~FTestEnhancedAuthProvider() override = default;
+
+	virtual FMqttifyCredentials GetCredentials() override
+	{
+		return FMqttifyCredentials{TEXT("user"), TEXT("pass")};
+	}
+	virtual FString GetAuthMethod() override { return FString(TEXT("TEST-AUTH")); }
+	virtual TArray<uint8> GetInitialAuthData() override { return TArray<uint8>{0xCA}; }
+	virtual TArray<uint8> OnAuthChallenge(const TArray<uint8>& /*ServerData*/) override { return TArray<uint8>{0xFE}; }
+};
+
+static TSharedPtr<FArrayReader> EncodePacketToReader(const TSharedRef<IMqttifyControlPacket>& Packet)
+{
+	TArray<uint8> Bytes;
+	FMemoryWriter W(Bytes);
+	W.SetByteSwapping(true);
+	Packet->Encode(W);
+	TSharedPtr<FArrayReader> Reader = MakeShared<FArrayReader>();
+	Reader->SetByteSwapping(true);
+	Reader->Append(Bytes.GetData(), Bytes.Num());
+	return Reader;
+}
+
+BEGIN_DEFINE_SPEC(
+	FMqttifyConnectingEnhancedAuthSpec,
+	"Mqttify.Automation.ClientConnecting.EnhancedAuth",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ClientContext | EAutomationTestFlags::ServerContext |
+	EAutomationTestFlags::CommandletContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FMqttifyConnectingEnhancedAuthSpec)
+
+void FMqttifyConnectingEnhancedAuthSpec::Define()
+{
+	Describe("FMqttifyClientConnectingState enhanced auth flow", [this]
+	{
+		It("Responds to AUTH(Continue) with provider data and completes on CONNACK", [this]
+		{
+			// Settings with enhanced auth provider
+			FMqttifyConnectionSettingsBuilder Builder(TEXT("mqtt://localhost:1883"));
+			Builder.SetMqttProtocolVersion(EMqttifyProtocolVersion::Mqtt_5);
+			TSharedRef<IMqttifyCredentialsProvider> Provider = MakeShared<FTestEnhancedAuthProvider>();
+			Builder.SetCredentialsProvider(Provider);
+			const TSharedPtr<FMqttifyConnectionSettings> Settings = Builder.Build();
+			TestTrue(TEXT("Settings should be valid"), Settings.IsValid());
+			const FMqttifyConnectionSettingsRef SettingsRef = Settings.ToSharedRef();
+
+			TSharedRef<FMqttifyClientContext> Context = MakeShared<FMqttifyClientContext>(SettingsRef);
+			TSharedRef<FFakeTestSocket> Socket = MakeShared<FFakeTestSocket>(SettingsRef);
+
+			bool bBecameConnected = false;
+			FMqttifyClientState::FOnStateChangedDelegate OnStateChanged = FMqttifyClientState::FOnStateChangedDelegate::CreateLambda(
+				[&](const FMqttifyClientState* /*Prev*/, const TSharedPtr<FMqttifyClientState>& NewState)
+				{
+					bBecameConnected = NewState.IsValid() && NewState->GetState() == EMqttifyState::Connected;
+				});
+
+			TSharedRef<FMqttifyClientConnectingState> State = MakeShared<FMqttifyClientConnectingState>(OnStateChanged, Context, false, Socket);
+
+			// Trigger TryConnect which will send CONNECT with auth props
+			State->OnSocketConnect(true);
+
+			// Simulate server AUTH Continue with method+data
+			TArray<FMqttifyProperty> AuthProps;
+			AuthProps.Add({FMqttifyProperty::Create<EMqttifyPropertyIdentifier::AuthenticationMethod>(FString(TEXT("TEST-AUTH")))});
+			AuthProps.Add({FMqttifyProperty::Create<EMqttifyPropertyIdentifier::AuthenticationData>(TArray<uint8>{9,9})});
+			TSharedRef<FMqttifyAuthPacket> ServerAuth = MakeShared<FMqttifyAuthPacket>(EMqttifyReasonCode::ContinueAuthentication, FMqttifyProperties(AuthProps));
+			State->OnReceivePacket(EncodePacketToReader(ServerAuth));
+
+			// Validate client sent AUTH Continue with provider response {0xFE} and echoed method
+			{
+				const TArray<uint8>& OutBytes = Socket->GetLastSentBytes();
+				FArrayReader R; R.SetByteSwapping(true); R.Append(OutBytes.GetData(), OutBytes.Num());
+				const FMqttifyFixedHeader H = FMqttifyFixedHeader::Create(R);
+				TestEqual(TEXT("Outgoing packet type should be AUTH"), (int32)H.GetPacketType(), (int32)EMqttifyPacketType::Auth);
+				FMqttifyAuthPacket ClientAuth(R, H);
+				TestEqual(TEXT("Client AUTH rc"), (int32)ClientAuth.GetReasonCode(), (int32)EMqttifyReasonCode::ContinueAuthentication);
+				FString Method; TArray<uint8> Data;
+				for (const FMqttifyProperty& P : ClientAuth.GetProperties().GetProperties())
+				{
+					if (P.GetIdentifier() == EMqttifyPropertyIdentifier::AuthenticationMethod) { P.TryGetValue(Method); }
+					if (P.GetIdentifier() == EMqttifyPropertyIdentifier::AuthenticationData) { P.TryGetValue(Data); }
+				}
+				TestEqual(TEXT("Echoed method"), Method, FString(TEXT("TEST-AUTH")));
+				TestEqual(TEXT("Auth data length"), Data.Num(), 1);
+				if (Data.Num() == 1) { TestEqual(TEXT("Auth data byte"), (int32)Data[0], 0xFE); }
+			}
+
+			// Now simulate successful CONNACK (server may include method too per spec)
+			TArray<FMqttifyProperty> ConnAckProps;
+			ConnAckProps.Add({FMqttifyProperty::Create<EMqttifyPropertyIdentifier::AuthenticationMethod>(FString(TEXT("TEST-AUTH")))});
+			TSharedRef<TMqttifyConnAckPacket<EMqttifyProtocolVersion::Mqtt_5>> ServerConnAck = MakeShared<TMqttifyConnAckPacket<EMqttifyProtocolVersion::Mqtt_5>>(
+				false,
+				EMqttifyReasonCode::Success,
+				FMqttifyProperties(ConnAckProps));
+			State->OnReceivePacket(EncodePacketToReader(ServerConnAck));
+
+			TestTrue(TEXT("Should transition to Connected after CONNACK"), bBecameConnected);
+		});
+	});
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/Mqttify/Private/Tests/Packets/MqttifyConnectAuthProperties.spec.cpp
+++ b/Source/Mqttify/Private/Tests/Packets/MqttifyConnectAuthProperties.spec.cpp
@@ -1,0 +1,89 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "Packets/MqttifyConnectPacket.h"
+#include "Packets/Properties/MqttifyProperty.h"
+
+using namespace Mqttify;
+
+BEGIN_DEFINE_SPEC(
+    FMqttifyConnectAuthPropsSpec,
+    "Mqttify.Automation.Mqtt5.Connect.AuthProperties",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ClientContext | EAutomationTestFlags::ServerContext |
+    EAutomationTestFlags::CommandletContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FMqttifyConnectAuthPropsSpec)
+
+void FMqttifyConnectAuthPropsSpec::Define()
+{
+    Describe("CONNECT Authentication Method/Data properties (MQTT 5)", [this]
+    {
+        It("Should encode/decode Authentication Method and Data in CONNECT properties", [this]
+        {
+            const FString ClientId = TEXT("client-1");
+            const uint16 KeepAlive = 30;
+            const FString Username = TEXT("user");
+            const FString Password = TEXT("pass");
+
+            TArray<FMqttifyProperty> Properties;
+            Properties.Add({FMqttifyProperty::Create<EMqttifyPropertyIdentifier::AuthenticationMethod>(FString(TEXT("SCRAM-SHA-1"))) });
+            Properties.Add({FMqttifyProperty::Create<EMqttifyPropertyIdentifier::AuthenticationData>(TArray<uint8>{1,2,3,4})});
+
+            const auto Connect = MakeShared<TMqttifyConnectPacket<EMqttifyProtocolVersion::Mqtt_5>>(
+                ClientId,
+                KeepAlive,
+                Username,
+                Password,
+                false,
+                false,
+                FString(),
+                FString(),
+                EMqttifyQualityOfService::AtMostOnce,
+                FMqttifyProperties(),
+                FMqttifyProperties(Properties));
+
+            // Encode
+            TArray<uint8> Buffer;
+            FMemoryWriter Writer(Buffer, true);
+            Writer.SetByteSwapping(true);
+            Connect->Encode(Writer);
+
+            // Decode
+            FArrayReader Reader;
+            Reader.SetByteSwapping(true);
+            Reader.Append(Buffer.GetData(), Buffer.Num());
+
+            const FMqttifyFixedHeader Header = FMqttifyFixedHeader::Create(Reader);
+            auto Decoded = TMqttifyConnectPacket<EMqttifyProtocolVersion::Mqtt_5>(Reader, Header);
+
+            // Verify
+            bool bFoundMethod = false;
+            bool bFoundData = false;
+            for (const FMqttifyProperty& P : Decoded.GetProperties().GetProperties())
+            {
+                if (P.GetIdentifier() == EMqttifyPropertyIdentifier::AuthenticationMethod)
+                {
+                    FString Value;
+                    TestTrue(TEXT("Auth Method present"), P.TryGetValue(Value));
+                    TestEqual(TEXT("Auth Method value"), Value, FString(TEXT("SCRAM-SHA-1")));
+                    bFoundMethod = true;
+                }
+                else if (P.GetIdentifier() == EMqttifyPropertyIdentifier::AuthenticationData)
+                {
+                    TArray<uint8> Value;
+                    TestTrue(TEXT("Auth Data present"), P.TryGetValue(Value));
+                    TestEqual(TEXT("Auth Data length"), Value.Num(), 4);
+                    TestEqual(TEXT("Auth Data byte 0"), (int32)Value[0], 1);
+                    TestEqual(TEXT("Auth Data byte 1"), (int32)Value[1], 2);
+                    TestEqual(TEXT("Auth Data byte 2"), (int32)Value[2], 3);
+                    TestEqual(TEXT("Auth Data byte 3"), (int32)Value[3], 4);
+                    bFoundData = true;
+                }
+            }
+
+            TestTrue(TEXT("Auth Method property found"), bFoundMethod);
+            TestTrue(TEXT("Auth Data property found"), bFoundData);
+        });
+    });
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/Mqttify/Private/Tests/Support/FakeTestSocket.h
+++ b/Source/Mqttify/Private/Tests/Support/FakeTestSocket.h
@@ -1,0 +1,67 @@
+#pragma once
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Socket/Interface/MqttifySocketBase.h"
+#include "Misc/AutomationTest.h"
+
+namespace Mqttify
+{
+	class FFakeTestSocket final : public FMqttifySocketBase
+	{
+	public:
+		explicit FFakeTestSocket(const FMqttifyConnectionSettingsRef& InConnectionSettings)
+			: FMqttifySocketBase{InConnectionSettings}
+			, bConnected(false)
+		{
+		}
+
+		virtual ~FFakeTestSocket() override = default;
+
+		virtual void Connect() override
+		{
+			bConnected = true;
+			OnConnectDelegate.Broadcast(true);
+		}
+
+		virtual void Disconnect() override
+		{
+			if (bConnected)
+			{
+				bConnected = false;
+				OnDisconnectDelegate.Broadcast();
+			}
+		}
+
+		virtual void Close(int32 /*Code*/ = 1000, const FString& /*Reason*/ = FString()) override
+		{
+			Disconnect();
+		}
+
+		virtual bool IsConnected() const override
+		{
+			return bConnected;
+		}
+
+		virtual void Tick() override {}
+
+		virtual void Send(const TSharedRef<IMqttifyControlPacket>& InPacket) override
+		{
+			// Encode and keep the bytes for assertions in tests
+			LastSentBytes.Reset();
+			FMemoryWriter Writer(LastSentBytes);
+			Writer.SetByteSwapping(true);
+			InPacket->Encode(Writer);
+		}
+
+		const TArray<uint8>& GetLastSentBytes() const { return LastSentBytes; }
+
+	protected:
+		virtual void Send(const uint8* /*Data*/, uint32 /*Size*/) override {}
+
+	private:
+		bool bConnected;
+		TArray<uint8> LastSentBytes;
+	};
+}
+
+#endif // WITH_DEV_AUTOMATION_TESTS

--- a/Source/Mqttify/Public/Mqtt/Interface/IMqttifyCredentialsProvider.h
+++ b/Source/Mqttify/Public/Mqtt/Interface/IMqttifyCredentialsProvider.h
@@ -9,6 +9,26 @@ class IMqttifyCredentialsProvider
 public:
 	virtual ~IMqttifyCredentialsProvider() = default;
 	virtual FMqttifyCredentials GetCredentials() = 0;
+
+	/**
+	 * @brief // Enhanced authentication support (MQTT v5, AUTH packets)
+	 * @return the authentication method name if using enhanced auth (e.g., "SCRAM-SHA-1", "GS2-KRB5").
+	 * empty string if not using enhanced auth.
+	 **/
+	virtual FString GetAuthMethod() { return FString(); }
+
+	/**
+	 * 
+	 * @return Optional initial authentication data to include in CONNECT when the method requires client-first data.
+	 */
+	virtual TArray<uint8> GetInitialAuthData() { return TArray<uint8>(); }
+
+	/**
+	* @brief Handle a server AUTH challenge and return the next client authentication data.
+	 * @return The response to the server challenge.
+	 * The default implementation returns an empty array, meaning no additional data.
+	 */
+	virtual TArray<uint8> OnAuthChallenge(const TArray<uint8>& /*ServerData*/) { return TArray<uint8>(); }
 };
 
 using FMqttifyCredentialsProviderPtr = TSharedPtr<IMqttifyCredentialsProvider>;


### PR DESCRIPTION
feat(mqtt5/auth): add enhanced authentication (AUTH packets, 
method/data) and tests

- Include `AuthenticationMethod` and optional `AuthenticationData` in 
CONNECT (MQTT 5).
- Handle server `AUTH` packets in 
`FMqttifyClientConnectingState`:
  - Support `ContinueAuthentication` with method validation and 
  challenge/response via credentials provider.
  - Accept `Success`; error and disconnect on other reason codes.
- Extend `IMqttifyCredentialsProvider` with `GetAuthMethod`, 
 `GetInitialAuthData`, and `OnAuthChallenge` for pluggable flows (e.g., 
 SCRAM).
- Add tests:
  - `MqttifyConnectingEnhancedAuth.spec` to exercise the full 
   enhanced-auth handshake.
  - `MqttifyConnectAuthProperties.spec` to verify CONNECT property 
   encode/decode.
  - `FakeTestSocket` utility to capture sent bytes during tests.
- Minor tidy-ups and logging.